### PR TITLE
ci: add missing ci scripts, fix clippy warnings

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -14,7 +14,7 @@ mod poly_benches {
 
     /// Benchmarks multiplication of two polynomials.
     fn multiplication(c: &mut Criterion) {
-        let mut group = c.benchmark_group("Polynomial multiplication Group");
+        let mut group = c.benchmark_group("Polynomial multiplication");
         let mut rng = XorShiftRng::from_seed(RNG_SEED);
         for deg in TEST_DEGREES {
             let parameter_string = format!("{}", deg);

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,6 +1,6 @@
 use blsttc::poly::Poly;
 use blsttc::Fr;
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use ff::Field;
 
 const TEST_DEGREES: [usize; 4] = [5, 10, 20, 40];
@@ -14,72 +14,89 @@ mod poly_benches {
 
     /// Benchmarks multiplication of two polynomials.
     fn multiplication(c: &mut Criterion) {
+        let mut group = c.benchmark_group("Polynomial multiplication Group");
         let mut rng = XorShiftRng::from_seed(RNG_SEED);
-        c.bench_function_over_inputs(
-            "Polynomial multiplication",
-            move |b, &&deg| {
-                let rand_factors = || {
-                    let lhs = Poly::random(deg, &mut rng);
-                    let rhs = Poly::random(deg, &mut rng);
-                    (lhs, rhs)
-                };
-                b.iter_with_setup(rand_factors, |(lhs, rhs)| &lhs * &rhs)
-            },
-            &TEST_DEGREES,
-        );
+        for deg in TEST_DEGREES {
+            let parameter_string = format!("{}", deg);
+            group.bench_with_input(
+                BenchmarkId::new("Polynomial multiplication", parameter_string),
+                &deg,
+                |b, deg| {
+                    let rand_factors = || {
+                        let lhs = Poly::random(*deg, &mut rng);
+                        let rhs = Poly::random(*deg, &mut rng);
+                        (lhs, rhs)
+                    };
+                    b.iter_with_setup(rand_factors, |(lhs, rhs)| &lhs * &rhs)
+                },
+            );
+        }
+        group.finish();
     }
 
     /// Benchmarks subtraction of two polynomials
     fn subtraction(c: &mut Criterion) {
+        let mut group = c.benchmark_group("Polynomial subtraction");
         let mut rng = XorShiftRng::from_seed(RNG_SEED);
-        c.bench_function_over_inputs(
-            "Polynomial subtraction",
-            move |b, &&deg| {
-                let rand_factors = || {
-                    let lhs = Poly::random(deg, &mut rng);
-                    let rhs = Poly::random(deg, &mut rng);
-                    (lhs, rhs)
-                };
-                b.iter_with_setup(rand_factors, |(lhs, rhs)| &lhs - &rhs)
-            },
-            &TEST_DEGREES,
-        );
+        for deg in TEST_DEGREES {
+            let parameter_string = format!("{}", deg);
+            group.bench_with_input(
+                BenchmarkId::new("Polynomial subtraction", parameter_string),
+                &deg,
+                |b, deg| {
+                    let rand_factors = || {
+                        let lhs = Poly::random(*deg, &mut rng);
+                        let rhs = Poly::random(*deg, &mut rng);
+                        (lhs, rhs)
+                    };
+                    b.iter_with_setup(rand_factors, |(lhs, rhs)| &lhs - &rhs)
+                },
+            );
+        }
     }
 
     /// Benchmarks addition of two polynomials
     fn addition(c: &mut Criterion) {
+        let mut group = c.benchmark_group("Polynomial addition");
         let mut rng = XorShiftRng::from_seed(RNG_SEED);
-        c.bench_function_over_inputs(
-            "Polynomial addition",
-            move |b, &&deg| {
-                let rand_factors = || {
-                    let lhs = Poly::random(deg, &mut rng);
-                    let rhs = Poly::random(deg, &mut rng);
-                    (lhs, rhs)
-                };
-                b.iter_with_setup(rand_factors, |(lhs, rhs)| &lhs + &rhs)
-            },
-            &TEST_DEGREES,
-        );
+        for deg in TEST_DEGREES {
+            let parameter_string = format!("{}", deg);
+            group.bench_with_input(
+                BenchmarkId::new("Polynomial addition", parameter_string),
+                &deg,
+                |b, deg| {
+                    let rand_factors = || {
+                        let lhs = Poly::random(*deg, &mut rng);
+                        let rhs = Poly::random(*deg, &mut rng);
+                        (lhs, rhs)
+                    };
+                    b.iter_with_setup(rand_factors, |(lhs, rhs)| &lhs + &rhs)
+                },
+            );
+        }
     }
 
     /// Benchmarks Lagrange interpolation for a polynomial.
     fn interpolate(c: &mut Criterion) {
+        let mut group = c.benchmark_group("Polynomial interpolation");
         let mut rng = XorShiftRng::from_seed(RNG_SEED);
-        c.bench_function_over_inputs(
-            "Polynomial interpolation",
-            move |b, &&deg| {
-                b.iter_with_setup(
-                    || {
-                        (0..=deg)
-                            .map(|i| (i, Fr::random(&mut rng)))
-                            .collect::<Vec<_>>()
-                    },
-                    Poly::interpolate,
-                )
-            },
-            &TEST_DEGREES,
-        );
+        for deg in TEST_DEGREES {
+            let parameter_string = format!("{}", deg);
+            group.bench_with_input(
+                BenchmarkId::new("Polynomial interpolation", parameter_string),
+                &deg,
+                |b, deg| {
+                    b.iter_with_setup(
+                        || {
+                            (0..=*deg)
+                                .map(|i| (i, Fr::random(&mut rng)))
+                                .collect::<Vec<_>>()
+                        },
+                        Poly::interpolate,
+                    )
+                },
+            );
+        }
     }
 
     criterion_group! {
@@ -99,26 +116,30 @@ mod public_key_set_benches {
     /// Benchmarks combining signatures
     fn combine_signatures(c: &mut Criterion) {
         let mut rng = XorShiftRng::from_seed(RNG_SEED);
+        let mut group = c.benchmark_group("Combine Signatures");
         let msg = "Test message";
-        c.bench_function_over_inputs(
-            "Combine Signatures",
-            move |b, &&threshold| {
-                let sk_set = SecretKeySet::random(threshold, &mut rng);
-                let pk_set = sk_set.public_keys();
-                let sigs: BTreeMap<_, _> = (0..=threshold)
-                    .map(|i| {
-                        let sig = sk_set.secret_key_share(i).sign(msg);
-                        (i, sig)
+        for threshold in TEST_THRESHOLDS {
+            let parameter_string = format!("{}", threshold);
+            group.bench_with_input(
+                BenchmarkId::new("Combine Signatures", parameter_string),
+                &threshold,
+                |b, threshold| {
+                    let sk_set = SecretKeySet::random(*threshold, &mut rng);
+                    let pk_set = sk_set.public_keys();
+                    let sigs: BTreeMap<_, _> = (0..=*threshold)
+                        .map(|i| {
+                            let sig = sk_set.secret_key_share(i).sign(msg);
+                            (i, sig)
+                        })
+                        .collect();
+                    b.iter(|| {
+                        pk_set
+                            .combine_signatures(&sigs)
+                            .expect("could not combine signatures");
                     })
-                    .collect();
-                b.iter(|| {
-                    pk_set
-                        .combine_signatures(&sigs)
-                        .expect("could not combine signatures");
-                })
-            },
-            &TEST_THRESHOLDS,
-        );
+                },
+            );
+        }
     }
 
     criterion_group! {

--- a/scripts/clippy
+++ b/scripts/clippy
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -x -e
+
+cargo clippy "$@" --all-targets

--- a/scripts/tests
+++ b/scripts/tests
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -x -e
+
+cargo test "$@" --release -- --nocapture

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1155,7 +1155,7 @@ mod tests {
         ];
         // no SecretKey::from_bytes method, so use bincode which requires
         // little endian bytes.
-        let mut leskbytes = skbytes.clone();
+        let mut leskbytes = skbytes;
         leskbytes.reverse();
         let sk: SecretKey = bincode::deserialize(&leskbytes).unwrap();
         let pk = sk.public_key();
@@ -1166,7 +1166,7 @@ mod tests {
         assert_eq!(sigbytes, sig.to_bytes());
         // signature can be verified
         let is_valid = pk.verify(&sig, msgbytes);
-        assert_eq!(is_valid, true);
+        assert!(is_valid);
     }
 
     #[test]


### PR DESCRIPTION
- add missing CI scripts
- fix clippy warnings
- replace deprecated bench_function_over_inputs with BenchmarkGroup as clippy suggests