### PR TITLE
feat: add pub fn to_bytes() to Ciphertext

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -566,10 +566,41 @@ impl Ciphertext {
     pub fn to_bytes(&self) -> Vec<u8> {
         let Ciphertext(ref u, ref v, ref w) = *self;
         let mut result: Vec<u8> = Default::default();
-        result.append(&mut u.into_affine().into_compressed().as_ref().to_vec());
-        result.append(&mut v.clone());
-        result.append(&mut w.into_affine().into_compressed().as_ref().to_vec());
+        result.extend(u.into_affine().into_compressed().as_ref());
+        result.extend(w.into_affine().into_compressed().as_ref());
+        result.extend(v);
         result
+    }
+
+    /// Returns the Ciphertext with the given representation, if valid.
+    pub fn from_bytes(bytes: &[u8]) -> FromBytesResult<Self> {
+        if bytes.len() < PK_SIZE + SIG_SIZE + 1 {
+            return Err(FromBytesError::Invalid);
+        }
+
+        let mut u_compressed: <G1Affine as CurveAffine>::Compressed = EncodedPoint::empty();
+        u_compressed.as_mut().copy_from_slice(&bytes[0..PK_SIZE]);
+
+        let mut w_compressed: <G2Affine as CurveAffine>::Compressed = EncodedPoint::empty();
+        w_compressed
+            .as_mut()
+            .copy_from_slice(&bytes[PK_SIZE..PK_SIZE + SIG_SIZE]);
+
+        let v: Vec<u8> = (&bytes[PK_SIZE + SIG_SIZE..]).to_vec();
+
+        Ok(Self(
+            u_compressed
+                .into_affine()
+                .ok()
+                .ok_or(FromBytesError::Invalid)?
+                .into_projective(),
+            v,
+            w_compressed
+                .into_affine()
+                .ok()
+                .ok_or(FromBytesError::Invalid)?
+                .into_projective(),
+        ))
     }
 }
 
@@ -1060,6 +1091,10 @@ mod tests {
         assert_eq!(pk, pk2);
         let sig2 = Signature::from_bytes(sig.to_bytes()).expect("invalid sig representation");
         assert_eq!(sig, sig2);
+        let cipher = sk.public_key().encrypt(b"secret msg");
+        let cipher2 =
+            Ciphertext::from_bytes(&cipher.to_bytes()).expect("invalid cipher representation");
+        assert_eq!(cipher, cipher2);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -561,6 +561,16 @@ impl Ciphertext {
         let hash = hash_g1_g2(*u, v);
         PEngine::pairing(G1Affine::one(), *w) == PEngine::pairing(*u, hash)
     }
+
+    /// Returns byte representation of Ciphertext
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let Ciphertext(ref u, ref v, ref w) = *self;
+        let mut result: Vec<u8> = Default::default();
+        result.append(&mut u.into_affine().into_compressed().as_ref().to_vec());
+        result.append(&mut v.clone());
+        result.append(&mut w.into_affine().into_compressed().as_ref().to_vec());
+        result
+    }
 }
 
 /// A decryption share. A threshold of decryption shares can be used to decrypt a message.


### PR DESCRIPTION
I need to access the Ciphertext bytes to use in a sha3 hash, so I made a fn to obtain them.

An alternative is to use bincode::serialize(), but that returns a Result which is not desirable for me and seems unnecessary.

There might be a more efficient way to impl that would avoid use of to_vec() and clone().  I just looked at how hash() was implemented and adapted it.

I compared the resulting bytes with those of bincode::serialize() and they are close,   The difference is that the bincode bytes encodes the length of the Vec (40 in this case) and some extra 0's, maybe padding.  My version simply concats the bytes of the 3 fields.

Example:
```
cipher bincode  bytes: [162, 121, 74, 99, 145, 111, 26, 155, 132, 244, 64, 130, 117, 128, 48, 207, 141, 173, 127, 83, 12, 138, 192, 23, 83, 160, 91, 152, 41, 49, 61, 29, 252, 158, 221, 197, 143, 167, 187, 205, 105, 117, 120, 32, 33, 73, 4, 204, 40, 0, 0, 0, 0, 0, 0, 0, 237, 15, 85, 28, 42, 86, 213, 83, 225, 39, 86, 200, 210, 242, 54, 80, 178, 1, 95, 43, 176, 211, 188, 129, 49, 101, 68, 250, 114, 218, 109, 22, 224, 226, 192, 186, 141, 20, 74, 0, 148, 58, 106, 108, 36, 238, 184, 236, 128, 7, 56, 202, 131, 166, 72, 156, 148, 204, 81, 211, 248, 55, 115, 185, 74, 3, 240, 48, 33, 65, 239, 225, 140, 112, 211, 8, 75, 188, 199, 57, 24, 24, 162, 108, 1, 147, 155, 101, 21, 243, 74, 27, 92, 201, 191, 170, 72, 133, 3, 72, 35, 153, 206, 31, 19, 113, 20, 214, 208, 44, 137, 131, 45, 47, 69, 238, 136, 212, 104, 6, 49, 151, 247, 34, 20, 132, 118, 122, 137, 136, 98, 47, 60, 94, 81, 36]

cipher to_bytes bytes: [162, 121, 74, 99, 145, 111, 26, 155, 132, 244, 64, 130, 117, 128, 48, 207, 141, 173, 127, 83, 12, 138, 192, 23, 83, 160, 91, 152, 41, 49, 61, 29, 252, 158, 221, 197, 143, 167, 187, 205, 105, 117, 120, 32, 33, 73, 4, 204, 237, 15, 85, 28, 42, 86, 213, 83, 225, 39, 86, 200, 210, 242, 54, 80, 178, 1, 95, 43, 176, 211, 188, 129, 49, 101, 68, 250, 114, 218, 109, 22, 224, 226, 192, 186, 141, 20, 74, 0, 148, 58, 106, 108, 36, 238, 184, 236, 128, 7, 56, 202, 131, 166, 72, 156, 148, 204, 81, 211, 248, 55, 115, 185, 74, 3, 240, 48, 33, 65, 239, 225, 140, 112, 211, 8, 75, 188, 199, 57, 24, 24, 162, 108, 1, 147, 155, 101, 21, 243, 74, 27, 92, 201, 191, 170, 72, 133, 3, 72, 35, 153, 206, 31, 19, 113, 20, 214, 208, 44, 137, 131, 45, 47, 69, 238, 136, 212, 104, 6, 49, 151, 247, 34, 20, 132, 118, 122, 137, 136, 98, 47, 60, 94, 81, 36]
```
The extra bincode data is: `40, 0, 0, 0, 0, 0, 0, 0`

I did not impl a from_bytes() as I presently don't need it.  If anyone wants to, the Byte sequence is:
* G1Compressed: 48 bytes
* Vec: variable length
* G2Compressed: 96 bytes.


Finally, I ran `cargo clippy --all-targets --all-features` and it gives a bunch of warnings and errors.  But this also happens without my change.  So maybe something to look into.