### PR TITLE
feat: make SecretKeySet::secret_key() public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -781,8 +781,7 @@ impl SecretKeySet {
     }
 
     /// Returns the secret master key.
-    #[cfg(test)]
-    fn secret_key(&self) -> SecretKey {
+    pub fn secret_key(&self) -> SecretKey {
         let mut fr = self.poly.evaluate(0);
         SecretKey::from_mut(&mut fr)
     }


### PR DESCRIPTION
This simply makes the secret key method public.  It can be determined anyway from the Poly, provided one has it.