### PR TITLE
feat: add SecretKeySet::poly() fn to make the Poly accessible

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -780,6 +780,11 @@ impl SecretKeySet {
         }
     }
 
+    /// Returns a reference to the polynomial
+    pub fn poly(&self) -> &Poly {
+        &self.poly
+    }
+
     /// Returns the secret master key.
     #[cfg(test)]
     fn secret_key(&self) -> SecretKey {


### PR DESCRIPTION
This way a SecretKeySet user can access the poly after SKS is created.

Previously, one must create the Poly, then SecretKeySet::from(poly), and store the poly separately, which is redundant / waste of space.