### PR TITLE
chore!: Force a breaking change

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -350,8 +350,9 @@ impl SecretKey {
         sk
     }
 
-    /// Creates a new random instance of `SecretKey`. If you want to use/define your own random
-    /// number generator, you should use the constructor:
+    /// Creates a new random instance of `SecretKey`.
+    ///
+    /// If you want to use/define your own random number generator, you should use the constructor:
     /// [`SecretKey::sample()`](struct.SecretKey.html#impl-Distribution<SecretKey>). If you do not
     /// need to specify your own RNG, you should use the
     /// [`SecretKey::random()`](struct.SecretKey.html#method.random) constructor, which uses


### PR DESCRIPTION
- dca6363 **chore!: Force a breaking change**

  PR #11 changed existing `from_bytes` methods to only accept `[u8; N]`
  rather than `Borrow<[u8; N]>`. This is a breaking change, as it means
  references (`&[u8; N]`) can no longer be passed.
  
  Since GitHub's rebase merge skips empty commits, this has to change
  *something*, so a doc comment was reformatted to improve its output
  (separating the header from the content).
  
  BREAKING CHANGE: `PublicKey::from_bytes`, `PublicKeyShare::from_bytes`,
  `Signature::from_bytes` and `SignatureShare::from_bytes` can no longer
  take `&[u8; N]`, and must be called with `[u8; N]` instead. This may
  require additional copying/cloning.
