### PR TITLE
From blstrs primitives pr

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,6 +99,13 @@ impl From<PublicKey> for G1Affine {
     }
 }
 
+/// Utility to convert blst to blsttc types
+impl From<G1Affine> for PublicKey {
+    fn from(item: G1Affine) -> Self {
+        PublicKey(item.into())
+    }
+}
+
 /// Utility to compare between blsttc and blst types
 impl std::cmp::PartialEq<G1> for PublicKey {
     fn eq(&self, other: &G1) -> bool {
@@ -347,7 +354,7 @@ impl fmt::Debug for SecretKey {
 }
 
 /// Utility to convert blsttc to blst types
-impl From<SecretKey> for Fr {
+impl From<SecretKey> for blstrs::Scalar {
     fn from(item: SecretKey) -> Self {
         item.0
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,6 +85,35 @@ impl Ord for PublicKey {
     }
 }
 
+/// Utility to convert blsttc to blst types
+impl From<PublicKey> for G1 {
+    fn from(item: PublicKey) -> Self {
+        item.0
+    }
+}
+
+/// Utility to convert blsttc to blst types
+impl From<PublicKey> for G1Affine {
+    fn from(item: PublicKey) -> Self {
+        item.0.to_affine()
+    }
+}
+
+/// Utility to compare between blsttc and blst types
+impl std::cmp::PartialEq<G1> for PublicKey {
+    fn eq(&self, other: &G1) -> bool {
+        &self.0 == other
+    }
+}
+
+/// Utility to compare between blsttc and blst types
+impl std::cmp::PartialEq<G1Affine> for PublicKey {
+    fn eq(&self, other: &G1Affine) -> bool {
+        // TODO is there a way to avoid the to_affine() by doing some cheap op on other?
+        &self.0.to_affine() == other
+    }
+}
+
 impl PublicKey {
     /// Returns `true` if the signature matches the element of `G2`.
     pub fn verify_g2<H: Into<G2Affine>>(&self, sig: &Signature, hash: H) -> bool {
@@ -314,6 +343,20 @@ impl Distribution<SecretKey> for Standard {
 impl fmt::Debug for SecretKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("SecretKey").field(&DebugDots).finish()
+    }
+}
+
+/// Utility to convert blsttc to blst types
+impl From<SecretKey> for Fr {
+    fn from(item: SecretKey) -> Self {
+        item.0
+    }
+}
+
+/// Utility to compare between blsttc and blst types
+impl std::cmp::PartialEq<Fr> for SecretKey {
+    fn eq(&self, other: &Fr) -> bool {
+        &self.0 == other
     }
 }
 
@@ -1143,7 +1186,7 @@ mod tests {
         let sig = sk.sign("Please sign here: ______");
         let pk = sk.public_key();
         let ser_pk = bincode::serialize(&pk).expect("serialize public key");
-        let deser_pk = bincode::deserialize(&ser_pk).expect("deserialize public key");
+        let deser_pk: PublicKey = bincode::deserialize(&ser_pk).expect("deserialize public key");
         assert_eq!(ser_pk.len(), PK_SIZE);
         assert_eq!(pk, deser_pk);
         let ser_sig = bincode::serialize(&sig).expect("serialize signature");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,6 +93,13 @@ impl From<PublicKey> for G1 {
 }
 
 /// Utility to convert blsttc to blst types
+impl From<G1> for PublicKey {
+    fn from(item: G1) -> Self {
+        PublicKey(item)
+    }
+}
+
+/// Utility to convert blsttc to blst types
 impl From<PublicKey> for G1Affine {
     fn from(item: PublicKey) -> Self {
         item.0.to_affine()

--- a/src/serde_impl.rs
+++ b/src/serde_impl.rs
@@ -363,7 +363,7 @@ mod tests {
             let sk: SecretKey = rng.gen();
             let ser_ref = bincode::serialize(&SerdeSecret(&sk)).expect("serialize secret key");
 
-            let de = bincode::deserialize(&ser_ref).expect("deserialize secret key");
+            let de: SecretKey = bincode::deserialize(&ser_ref).expect("deserialize secret key");
             assert_eq!(sk, de);
 
             let de_serde_secret: SerdeSecret<SecretKey> =
@@ -386,7 +386,8 @@ mod tests {
             let sk: SecretKeyShare = rng.gen();
             let ser_ref = bincode::serialize(&SerdeSecret(&sk)).expect("serialize secret key");
 
-            let de = bincode::deserialize(&ser_ref).expect("deserialize secret key");
+            let de: SecretKeyShare =
+                bincode::deserialize(&ser_ref).expect("deserialize secret key");
             assert_eq!(sk, de);
 
             let de_serde_secret: SerdeSecret<SecretKeyShare> =


### PR DESCRIPTION
This adds some plumbing for converting from/into blst types for PublicKey/SecretKey and also for comparisons with blst types.

These make the sn_dbc public API and code much cleaner because it uses blst_ringct (based on blstrs) and blsttc.  With these additions in place, one can pass blsttc PK and SK directly to ringct APIs that accept eg Into&lt;G1Affine>.

This PR does not address the multisig types (*Set, *Share) because ringct+sn_dbc does not yet support multisig for owner keys.  Still, it might make a nice addition for symmetry.