### PR TITLE
chore: re-export crates used in our public API

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,11 @@
 #![allow(clippy::derive_hash_xor_eq)]
 #![warn(missing_docs)]
 
+// re-export crates used in our public API.
+pub use blstrs;
 pub use group;
+pub use rand;
+pub use serde; // todo: add serde feature flag later.
 
 mod cmp_pairing;
 mod convert;


### PR DESCRIPTION
The idea is to give API consumers the option to use the exported crates
without needing explicit Cargo.toml entries.

This in turn decouples dependencies and reduces conflicts.

See rationale/discussion here:
https://github.com/rust-lang/api-guidelines/discussions/176