### PR TITLE
feat: derive [De-]Serialize on Error

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,8 +1,10 @@
 //! Crypto errors.
 use thiserror::Error;
 
+use serde::{Deserialize, Serialize};
+
 /// A crypto error.
-#[derive(Clone, Eq, PartialEq, Debug, Error)]
+#[derive(Clone, Eq, PartialEq, Debug, Error, Serialize, Deserialize)]
 pub enum Error {
     /// Not enough signature shares.
     #[error("Not enough shares for interpolation")]


### PR DESCRIPTION
This is necessary for serializing errors across the network.