### PR TITLE
feat: simple example for generating a keypair

### DIFF
--- a/examples/basic_keypair.rs
+++ b/examples/basic_keypair.rs
@@ -1,0 +1,12 @@
+use blsttc::SecretKey;
+
+/// Extremely simple example to effectively provide a little util program for quickly generating a
+/// BLS keypair and printing out the hex representation.
+///
+/// Could be extended to demonstrate the use of shares.
+fn main() {
+    let sk = SecretKey::random();
+    let pk = sk.public_key();
+    println!("public key: {}", pk.to_hex());
+    println!("secret key: {}", sk.to_hex());
+}


### PR DESCRIPTION
This effectively provides a little utility program you can use to quickly generate keypairs. I needed them for tests I was writing that were using the library.

It could perhaps be extended to demonstrate the use of shares.