### PR TITLE
feat: remove getrandom feature list for wasm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,10 +35,6 @@ zeroize = "1.3.0"
   version = "2.0.1"
   features = [ "sha3" ]
 
-[target."cfg(target_arch = \"wasm32\")".dependencies.getrandom]
-version = "0.2"
-features = [ "js" ]
-
 [dev-dependencies]
 bincode = "1.3.3"
 criterion = "0.3.1"

--- a/src/poly.rs
+++ b/src/poly.rs
@@ -97,7 +97,7 @@ impl<B: Borrow<Poly>> ops::Add<B> for Poly {
     }
 }
 
-impl<'a> ops::Add<Fr> for Poly {
+impl ops::Add<Fr> for Poly {
     type Output = Poly;
 
     fn add(mut self, rhs: Fr) -> Self::Output {
@@ -111,7 +111,7 @@ impl<'a> ops::Add<Fr> for Poly {
     }
 }
 
-impl<'a> ops::Add<u64> for Poly {
+impl ops::Add<u64> for Poly {
     type Output = Poly;
 
     fn add(self, rhs: u64) -> Self::Output {
@@ -150,7 +150,7 @@ impl<B: Borrow<Poly>> ops::Sub<B> for Poly {
     }
 }
 
-impl<'a> ops::Sub<Fr> for Poly {
+impl ops::Sub<Fr> for Poly {
     type Output = Poly;
 
     fn sub(self, mut rhs: Fr) -> Self::Output {
@@ -159,7 +159,7 @@ impl<'a> ops::Sub<Fr> for Poly {
     }
 }
 
-impl<'a> ops::Sub<u64> for Poly {
+impl ops::Sub<u64> for Poly {
     type Output = Poly;
 
     fn sub(self, rhs: u64) -> Self::Output {


### PR DESCRIPTION
It's better to allow the upstream consumer of this library to specify
how they want to manage wasm compilation. For example I'm using the
"custom" feature of getrandom instead of the "js' feature. Having it
specified in this library enforces "js" feature which makes getrandom
inconsistent across my wasm project, some is custom, some is js.