### PR TITLE
Check pubkey for 0 to prevent rogue key attack variant

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -638,7 +638,7 @@ impl Ciphertext {
         wbytes.copy_from_slice(&bytes[PK_SIZE..PK_SIZE + SIG_SIZE]);
         let w = g2_from_bytes(wbytes)?;
 
-        let v: Vec<u8> = (&bytes[PK_SIZE + SIG_SIZE..]).to_vec();
+        let v: Vec<u8> = (bytes[PK_SIZE + SIG_SIZE..]).to_vec();
 
         Ok(Self(u, v, w))
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,10 +133,16 @@ impl std::cmp::PartialEq<G1Affine> for PublicKey {
 }
 
 impl PublicKey {
+    // Utility to check if public key is 0, this is a measure to prevent rogue public key attacks
+    fn is_zero(&self) -> bool {
+        self.0.is_identity().unwrap_u8() == 1
+    }
+
     /// Returns `true` if the signature matches the element of `G2`.
     pub fn verify_g2<H: Into<G2Affine>>(&self, sig: &Signature, hash: H) -> bool {
-        PEngine::pairing(&self.0.to_affine(), &hash.into())
-            == PEngine::pairing(&G1Affine::generator(), &sig.0.to_affine())
+        !self.is_zero()
+            && PEngine::pairing(&self.0.to_affine(), &hash.into())
+                == PEngine::pairing(&G1Affine::generator(), &sig.0.to_affine())
     }
 
     /// Returns `true` if the signature matches the message.


### PR DESCRIPTION
This is an attempt to prevent an attack in the kind described in this article:
https://medium.com/asecuritysite-when-bob-met-alice/smart-wallet-vulnerabily-using-the-rogue-public-key-attack-56d218f6a31d

In this attack one can sign any message with the public key `0` with a signature `0` and pass all verifications. 
This PR addresses this by checking that the pubkey is different from `0`. 

Comes along with a test that reproduces the attack and proves that the extra check in `verify_g2` protects us from this attack. 