### PR TITLE
feat(repr): switch internal representation to Affine

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -418,10 +418,10 @@ mod public_key_benches {
                 let pk = sk.public_key();
                 let mut msg = [0u8; 1000];
                 rng.fill_bytes(&mut msg);
-                let sig = sk.sign(&msg);
+                let sig = sk.sign(msg);
                 (pk, msg, sig)
             };
-            b.iter_with_setup(rand_factors, |(pk, msg, sig)| pk.verify(&sig, &msg));
+            b.iter_with_setup(rand_factors, |(pk, msg, sig)| pk.verify(&sig, msg));
         });
     }
 
@@ -435,11 +435,11 @@ mod public_key_benches {
                 let pk = sk.public_key();
                 let mut msg = [0u8; 1000];
                 rng.fill_bytes(&mut msg);
-                let hash = hash_g2(&msg);
-                let sig = sk.sign_g2(&hash);
+                let hash = hash_g2(msg);
+                let sig = sk.sign_g2(hash);
                 (pk, hash, sig)
             };
-            b.iter_with_setup(rand_factors, |(pk, hash, sig)| pk.verify_g2(&sig, &hash));
+            b.iter_with_setup(rand_factors, |(pk, hash, sig)| pk.verify_g2(&sig, hash));
         });
     }
 
@@ -471,7 +471,7 @@ mod public_key_benches {
                 rng.fill_bytes(&mut msg);
                 (pk, msg)
             };
-            b.iter_with_setup(rand_factors, |(pk, msg)| pk.encrypt(&msg));
+            b.iter_with_setup(rand_factors, |(pk, msg)| pk.encrypt(msg));
         });
     }
 
@@ -499,7 +499,7 @@ mod secret_key_benches {
                 rng.fill_bytes(&mut msg);
                 (sk, msg)
             };
-            b.iter_with_setup(rand_factors, |(sk, msg)| sk.sign(&msg));
+            b.iter_with_setup(rand_factors, |(sk, msg)| sk.sign(msg));
         });
     }
 
@@ -512,10 +512,10 @@ mod secret_key_benches {
                 let sk = SecretKey::random();
                 let mut msg = [0u8; 1000];
                 rng.fill_bytes(&mut msg);
-                let hash = hash_g2(&msg);
+                let hash = hash_g2(msg);
                 (sk, hash)
             };
-            b.iter_with_setup(rand_factors, |(sk, hash)| sk.sign_g2(&hash));
+            b.iter_with_setup(rand_factors, |(sk, hash)| sk.sign_g2(hash));
         });
     }
 
@@ -528,10 +528,10 @@ mod secret_key_benches {
                 let sk = SecretKey::random();
                 let mut msg = [0u8; 1000];
                 rng.fill_bytes(&mut msg);
-                let hash = hash_g2(&msg);
+                let hash = hash_g2(msg);
                 (sk, hash)
             };
-            b.iter_with_setup(rand_factors, |(sk, hash)| sk.sign_g2(&hash));
+            b.iter_with_setup(rand_factors, |(sk, hash)| sk.sign_g2(hash));
         });
     }
 
@@ -545,7 +545,7 @@ mod secret_key_benches {
                 let pk = sk.public_key();
                 let mut msg = [0u8; 1000];
                 rng.fill_bytes(&mut msg);
-                let ct = pk.encrypt(&msg);
+                let ct = pk.encrypt(msg);
                 (sk, ct)
             };
             b.iter_with_setup(rand_factors, |(sk, ct)| sk.decrypt(&ct));
@@ -576,7 +576,7 @@ mod ciphertext_benches {
                 let pk = sk.public_key();
                 let mut msg = [0u8; 1000];
                 rng.fill_bytes(&mut msg);
-                pk.encrypt(&msg)
+                pk.encrypt(msg)
             };
             b.iter_with_setup(rand_factors, |ct| ct.verify());
         });
@@ -606,7 +606,7 @@ mod lib_benches {
                 rng.fill_bytes(&mut msg);
                 msg
             };
-            b.iter_with_setup(rand_factors, |msg| hash_g2(&msg));
+            b.iter_with_setup(rand_factors, hash_g2);
         });
     }
 

--- a/examples/basic_pkc.rs
+++ b/examples/basic_pkc.rs
@@ -43,7 +43,7 @@ fn main() {
     let msg = b"let's get pizza";
     let signed_msg = bob.create_signed_msg(msg);
     let serialized = serialize(&signed_msg).expect("Failed to serialize `SignedMsg`");
-    let ciphertext = alice.pk.encrypt(&serialized);
+    let ciphertext = alice.pk.encrypt(serialized);
 
     // Alice receives Bob's encrypted message. She decrypts the message using her secret key. She
     // then verifies that the signature of the plaintext is valid using Bob's public key.

--- a/src/cmp_pairing.rs
+++ b/src/cmp_pairing.rs
@@ -1,10 +1,10 @@
 use std::cmp::Ordering;
 
-use group::{prime::PrimeCurve, GroupEncoding};
+use group::prime::PrimeCurveAffine;
 
 /// Compares two curve elements and returns their `Ordering`.
-pub fn cmp_projective<G: PrimeCurve>(x: &G, y: &G) -> Ordering {
-    let xc = x.to_affine().to_bytes();
-    let yc = y.to_affine().to_bytes();
+pub fn cmp_affine<G: PrimeCurveAffine>(x: &G, y: &G) -> Ordering {
+    let xc = x.to_bytes();
+    let yc = y.to_bytes();
     xc.as_ref().cmp(yc.as_ref())
 }

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -4,7 +4,7 @@ use blst::blst_scalar;
 
 use crate::{
     error::{Error, Result},
-    Fr, DST, G1, G2, PK_SIZE, SIG_SIZE, SK_SIZE,
+    Fr, G1Affine, G2Affine, DST, PK_SIZE, SIG_SIZE, SK_SIZE,
 };
 
 pub(crate) fn derivation_index_into_fr(index: &[u8]) -> Fr {
@@ -43,18 +43,18 @@ pub(crate) fn fr_from_bytes(bytes: [u8; SK_SIZE]) -> Result<Fr> {
     Ok(fr.unwrap())
 }
 
-pub(crate) fn g1_from_bytes(bytes: [u8; PK_SIZE]) -> Result<G1> {
+pub(crate) fn g1_from_bytes(bytes: [u8; PK_SIZE]) -> Result<G1Affine> {
     // TODO IC remove unwrap here? I'm not sure if it's possible with CtOption
-    let g1 = G1::from_compressed(&bytes);
+    let g1 = G1Affine::from_compressed(&bytes);
     if g1.is_none().into() {
         return Err(Error::InvalidBytes);
     };
     Ok(g1.unwrap())
 }
 
-pub(crate) fn g2_from_bytes(bytes: [u8; SIG_SIZE]) -> Result<G2> {
+pub(crate) fn g2_from_bytes(bytes: [u8; SIG_SIZE]) -> Result<G2Affine> {
     // TODO IC remove unwrap here? I'm not sure if it's possible with CtOption
-    let g2 = G2::from_compressed(&bytes);
+    let g2 = G2Affine::from_compressed(&bytes);
     if g2.is_none().into() {
         return Err(Error::InvalidBytes);
     };

--- a/src/serde_impl.rs
+++ b/src/serde_impl.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::poly::{coeff_pos, BivarCommitment};
 use crate::serde_impl::serialize_secret_internal::SerializeSecret;
-use crate::{SecretKey, G1};
+use crate::{G1Affine, SecretKey};
 
 const ERR_DEG: &str = "commitment degree does not match coefficients";
 
@@ -121,7 +121,7 @@ struct WireBivarCommitment<'a> {
     /// The polynomial's degree in each of the two variables.
     degree: usize,
     /// The commitments to the coefficients.
-    coeff: Cow<'a, [G1]>,
+    coeff: Cow<'a, [G1Affine]>,
 }
 
 impl Serialize for BivarCommitment {
@@ -312,12 +312,12 @@ mod tests {
     use serde::{Deserialize, Serialize};
 
     use crate::poly::BivarPoly;
-    use crate::{Fr, G1Projective, G1};
+    use crate::{Fr, G1Affine, G1Projective};
 
     #[derive(Debug, Serialize, Deserialize)]
     pub struct Vecs {
         #[serde(with = "super::affine_vec")]
-        curve_points: Vec<G1>,
+        curve_points: Vec<G1Affine>,
         #[serde(with = "super::field_vec")]
         field_elements: Vec<Fr>,
     }


### PR DESCRIPTION
The current representation is Projective, this is quite large (144bytes for public keys). If we switch internal representation to Affine, we come down to 96bytes for public keys.

There's a small API breaking change, you sometimes need to pass by value when you used to be able pass by reference.

Everything else remains the same.

# size changes:
## Before this PR:
```
144	DecryptionShare - src/lib.rs:649:1: 649:74 (#0)
144	PublicKey - src/lib.rs:65:1: 65:68 (#0)
144	PublicKeyShare - src/lib.rs:207:1: 207:38 (#0)
288	Signature - src/lib.rs:254:1: 254:68 (#0)
288	SignatureShare - src/lib.rs:310:1: 310:42 (#0)
456	Ciphertext - src/lib.rs:576:1: 580:3 (#0)
```

## With this PR:
```
 96	DecryptionShare - src/lib.rs:643:1: 643:70 (#0)
 96	PublicKey - src/lib.rs:65:1: 65:64 (#0)
 96	PublicKeyShare - src/lib.rs:205:1: 205:38 (#0)
192	Signature - src/lib.rs:251:1: 251:64 (#0)
192	SignatureShare - src/lib.rs:307:1: 307:42 (#0)
312	Ciphertext - src/lib.rs:573:1: 577:3 (#0)
```

# perf changes:
All benches are roughly identical except for the `Commitment/addition` benches which are about 3x slower when we store commitments as Affine. I think this is due to the lack of `G1Affine::add_asign` forcing a lot of conversions there.
```
Commitment/addition/5   time:   [20.766 us 20.797 us 20.833 us]
                        change: [+370.86% +371.75% +372.66%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
Commitment/addition/10  time:   [37.463 us 37.536 us 37.611 us]
                        change: [+360.72% +362.00% +363.24%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
Commitment/addition/20  time:   [71.950 us 72.054 us 72.176 us]
                        change: [+366.31% +367.63% +368.90%] (p = 0.00 < 0.05)
                        Performance has regressed.
```