### PR TITLE
chore: fix link in readme for encryption paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The `blsttc` crate provides cryptographic keys with methods for signing and encr
 
 `blsttc` is an adaptation of the [threshold_crypto](https://github.com/poanetwork/threshold_crypto) crate using blast ([blst](https://github.com/supranational/blst)) for signing and verification speed improvements.
 
-The threshold signature scheme is described in [Threshold Signatures, Multisignatures and Blind Signatures Based on the Gap-Diffie-Hellman-Group Signature Scheme](https://www.iacr.org/archive/pkc2003/25670031/25670031.pdf) by Alexandra Boldyreva. This paper extends [Boneh-Lynn-Shacham](https://www.iacr.org/archive/asiacrypt2001/22480516.pdf) signatures to the threshold setting. Message encryption uses the [scheme by Baek and Zhang](http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.119.1717&rep=rep1&type=pdf).
+The threshold signature scheme is described in [Threshold Signatures, Multisignatures and Blind Signatures Based on the Gap-Diffie-Hellman-Group Signature Scheme](https://www.iacr.org/archive/pkc2003/25670031/25670031.pdf) by Alexandra Boldyreva. This paper extends [Boneh-Lynn-Shacham](https://www.iacr.org/archive/asiacrypt2001/22480516.pdf) signatures to the threshold setting. Message encryption uses the [scheme by Baek and Zhang](https://web.archive.org/web/20230610212925/https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.119.1717&rep=rep1&type=pdf).
 Our implementation is based on the [`pairing`](https://crates.io/crates/pairing) elliptic curve library.
 
 In a network environment, messages are signed and encrypted, and key and signature shares are distributed to network participants. A message can be decrypted and authenticated only with cooperation from at least `threshold +

--- a/examples/threshold_sig.rs
+++ b/examples/threshold_sig.rs
@@ -96,13 +96,10 @@ impl ChatNetwork {
                 .iter()
                 .fold(BTreeMap::new(), |mut all_pending, node| {
                     for (user_id, signed_msgs) in &node.pending {
-                        let user_msgs = all_pending.entry(*user_id).or_insert_with(BTreeMap::new);
+                        let user_msgs = all_pending.entry(*user_id).or_default();
                         for (msg, sigs) in signed_msgs.iter() {
                             let sigs = sigs.iter().cloned();
-                            user_msgs
-                                .entry(msg.to_string())
-                                .or_insert_with(Vec::new)
-                                .extend(sigs);
+                            user_msgs.entry(msg.to_string()).or_default().extend(sigs);
                         }
                     }
                     all_pending
@@ -164,9 +161,9 @@ impl Node {
         };
         self.pending
             .entry(user_id)
-            .or_insert_with(BTreeMap::new)
+            .or_default()
             .entry(msg)
-            .or_insert_with(Vec::new)
+            .or_default()
             .push(sig);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 
 // Clippy warns that it's dangerous to derive `PartialEq` and explicitly implement `Hash`, but the
 // `blstrs` types don't implement `Hash`, so we can't derive it.
-#![allow(clippy::derive_hash_xor_eq)]
+#![allow(clippy::derived_hash_with_manual_eq)]
 #![warn(missing_docs)]
 
 // re-export crates used in our public API.
@@ -1857,7 +1857,7 @@ mod tests {
         let mut rng = rand::thread_rng();
         // The threshold is 3, so 4 signature shares will suffice to decrypt.
         let sks = SecretKeySet::random(3, &mut rng);
-        let share_indexes = vec![5, 8, 7, 10];
+        let share_indexes = [5, 8, 7, 10];
         // all participants have the public key set and their key share.
         let pks = sks.public_keys();
         let key_shares: BTreeMap<_, _> = share_indexes


### PR DESCRIPTION
Link was broken giving status 401 "Token is required". Can't find another source but it's in archive.org so I've used that.